### PR TITLE
dsm.py:: only convert tenant to unicode if not None

### DIFF
--- a/deepsecurity/dsm.py
+++ b/deepsecurity/dsm.py
@@ -24,7 +24,10 @@ class Manager(core.CoreApi):
     core.CoreApi.__init__(self)
     self._hostname = None
     self._port = port
-    self._tenant = unicode(tenant, "utf-8")
+    if tenant:
+        self._tenant = unicode(tenant, "utf-8")
+    else:
+        self._tenant = None
     self._username = unicode(username, "utf-8")
     self._password = unicode(password, "utf-8")
     self._prefix = prefix


### PR DESCRIPTION
If the tenant is omitted when connecting to a DSM a TypeError is thrown as None can't be coerced
