### PR TITLE
Added explicit conversion for SOAP XML document to utf-8

### DIFF
--- a/deepsecurity/core.py
+++ b/deepsecurity/core.py
@@ -298,7 +298,7 @@ class CoreApi(object):
     # convert any nil values to the proper format
     soap_xml = re.sub(r'<([^>]+)></\1>', r'<\1 xsi:nil="true" />', soap_xml)
 
-    return soap_xml
+    return soap_xml.encode('utf-8')
 
   def log(self, message='', err=None, level='info'):
     """


### PR DESCRIPTION
SOAP documents were not being explicitly converted to utf-8 and this was preventing non-latin based tenants from being able to sign in.
