### PR TITLE
Code that makes deep-security-py compatible with Python 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeepSecurity.py
 
-A unified python SDK for the Deep Security APIs
+A unified python SDK for the Deep Security APIs, now compatible with Python 2.6
 
 ## Support
 

--- a/deepsecurity/computers.py
+++ b/deepsecurity/computers.py
@@ -122,25 +122,25 @@ class Computers(core.CoreDict):
         computer_obj = Computer(self.manager, computer, self.log)
         if computer_obj:
           self[computer_obj.id] = computer_obj
-          self.log("Added Computer {}".format(computer_obj.id), level='debug')
+          self.log("Added Computer {0}".format(computer_obj.id), level='debug')
           
           try:
             # add this computer to any appropriate groups on the Manager()
             if 'computer_group_id' in dir(computer_obj) and computer_obj.computer_group_id:
               if self.manager.computer_groups and self.manager.computer_groups.has_key(computer_obj.computer_group_id):
                 self.manager.computer_groups[computer_obj.computer_group_id].computers[computer_obj.id] = computer_obj
-                self.log("Added Computer {} to ComputerGroup {}".format(computer_obj.id, computer_obj.computer_group_id), level='debug')
+                self.log("Added Computer {0} to ComputerGroup {1}".format(computer_obj.id, computer_obj.computer_group_id), level='debug')
           except Exception, hostGroupid_err:
-            self.log("Could not add Computer {} to ComputerGroup".format(computer_obj.id), err=hostGroupid_err)
+            self.log("Could not add Computer {0} to ComputerGroup".format(computer_obj.id), err=hostGroupid_err)
 
           try: 
             # add this computer to any appropriate policies on the Manager()
             if 'policy_id' in dir(computer_obj) and computer_obj.policy_id:
               if self.manager.policies and self.manager.policies.has_key(computer_obj.policy_id):
                 self.manager.policies[computer_obj.policy_id].computers[computer_obj.id] = computer_obj
-                self.log("Added Computer {} to Policy {}".format(computer_obj.id, computer_obj.policy_id), level='debug')
+                self.log("Added Computer {0} to Policy {1}".format(computer_obj.id, computer_obj.policy_id), level='debug')
           except Exception, securityProfileid_err:
-            self.log("Could not add Computer {} to Policy".format(computer_obj.id), err=securityProfileid_err)
+            self.log("Could not add Computer {0} to Policy".format(computer_obj.id), err=securityProfileid_err)
 
     return len(self)
 
@@ -172,7 +172,7 @@ class ComputerGroups(core.CoreDict):
       elif group_id:
         call = self.manager._get_request_format(call='hostGroupRetrieve')
         call['data'] = {
-          'id': '{}'.format(group_id)
+          'id': '{0}'.format(group_id)
           }
     else:
       call = self.manager._get_request_format(call='hostGroupRetrieveAll')
@@ -185,7 +185,7 @@ class ComputerGroups(core.CoreDict):
         computer_group_obj = ComputerGroup(self.manager, group, self.log)
         if computer_group_obj:
           self[computer_group_obj.id] = computer_group_obj
-          self.log("Added ComputerGroup {}".format(computer_group_obj.id), level='debug')
+          self.log("Added ComputerGroup {0}".format(computer_group_obj.id), level='debug')
 
     return len(self)
 

--- a/deepsecurity/dsm.py
+++ b/deepsecurity/dsm.py
@@ -61,8 +61,8 @@ class Manager(core.CoreApi):
     """
     Return a better string representation
     """
-    dsm_port = ":{}".format(self.port) if self.port else ""
-    return "Manager <{}{}>".format(self.hostname, dsm_port)
+    dsm_port = ":{0}".format(self.port) if self.port else ""
+    return "Manager <{0}{1}>".format(self.hostname, dsm_port)
 
   # *******************************************************************
   # properties
@@ -124,9 +124,9 @@ class Manager(core.CoreApi):
     """
     Set the API endpoints based on the current configuration
     """
-    dsm_port = ":{}".format(self.port) if self.port else "" # allow for endpoints with no port specified
-    self._rest_api_endpoint = "https://{}{}/{}rest".format(self.hostname, dsm_port, self.prefix)
-    self._soap_api_endpoint = "https://{}{}/{}webservice/Manager".format(self.hostname, dsm_port, self.prefix)
+    dsm_port = ":{0}".format(self.port) if self.port else "" # allow for endpoints with no port specified
+    self._rest_api_endpoint = "https://{0}{1}/{2}rest".format(self.hostname, dsm_port, self.prefix)
+    self._soap_api_endpoint = "https://{0}{1}/{2}webservice/Manager".format(self.hostname, dsm_port, self.prefix)
 
   def _reset_session(self):
     """
@@ -153,7 +153,7 @@ class Manager(core.CoreApi):
     """
     user_credentials_path = os.path.expanduser('~/.deepsecurity/credentials')
     if os.path.exists(user_credentials_path):
-      self.log("Found local credentials file at [{}]".format(user_credentials_path))
+      self.log("Found local credentials file at [{0}]".format(user_credentials_path))
       credentials = {
         'username': None,
         'password': None,
@@ -175,10 +175,10 @@ class Manager(core.CoreApi):
         if v:
           if k in dir(self):
             try:
-              setattr(self, "_{}".format(k), v)
-              self.log("Loaded {} from local credentials file".format(k))
+              setattr(self, "_{0}".format(k), v)
+              self.log("Loaded {0} from local credentials file".format(k))
             except Exception, err:
-              self.log("Unable to load {} from local credentials file".format(k))
+              self.log("Unable to load {0} from local credentials file".format(k))
   
   def sign_in(self):
     """

--- a/deepsecurity/environments.py
+++ b/deepsecurity/environments.py
@@ -62,7 +62,7 @@ class CloudAccounts(core.CoreDict):
               'accessKey': aws_access_key,
               'secretKey': aws_secret_key,
               'cloudType': 'AMAZON',
-              'name': '{} / {}'.format(name, region_to_add),
+              'name': '{0} / {1}'.format(name, region_to_add),
               'cloudRegion': regions[region_to_add],
             },
           }

--- a/deepsecurity/policies.py
+++ b/deepsecurity/policies.py
@@ -27,9 +27,9 @@ class Policies(core.CoreDict):
         if policy_obj:
           try:
             self[policy_obj.id] = policy_obj
-            self.log("Added Policy {}".format(policy_obj.id), level='debug')
+            self.log("Added Policy {0}".format(policy_obj.id), level='debug')
           except Exception, err:
-            self.log("Could not add Policy {}".format(policy_obj), level='warning', err=err)
+            self.log("Could not add Policy {0}".format(policy_obj), level='warning', err=err)
 
     return len(self)
 
@@ -134,7 +134,7 @@ class Policies(core.CoreDict):
         if new_policy:
           self[new_policy.id] = new_policy
           result = new_policy.id
-          self.log("Added new policy #{}".format(new_policy.id))
+          self.log("Added new policy #{0}".format(new_policy.id))
       except Exception, err:
         self.log("Could not create new policy from API response", err=err)
     else:
@@ -168,7 +168,7 @@ class Rules(core.CoreDict):
       if get:
         soap_call = self.manager._get_request_format(call=call)
         if call == 'DPIRuleRetrieveAll':
-          self.log("Calling {}. This may take 15-30 seconds as the call returns a substantial amount of data".format(call), level='warning')
+          self.log("Calling {0}. This may take 15-30 seconds as the call returns a substantial amount of data".format(call), level='warning')
 
         response = self.manager._request(soap_call)
         if response and response['status'] == 200:
@@ -180,11 +180,13 @@ class Rules(core.CoreDict):
                 rule_obj.cve_numbers = rule_obj.cve_numbers.split(', ')
                 if type(rule_obj.cve_numbers) in [type(''), type(u'')]: rule_obj.cve_numbers = [ rule_obj.cve_numbers ]
                 
-              rule_id = '{}-{: >10}'.format(rule_key, i)
+              #TODO: find out what this is. 
+              rule_id = '{0}-'.format(rule_key) + '{0:10d}'.format(i)
+              #rule_id = rule_id + ('%10s' % i);
               if 'id' in dir(rule_obj): rule_id = rule_obj.id
               elif 'tbuid' in dir(rule_obj): rule_id = rule_obj.tbuid
               self[rule_key][rule_id] = rule_obj
-              self.log("Added Rule {} from call {}".format(rule_id, call), level='debug')
+              self.log("Added Rule {0} from call {1}".format(rule_id, call), level='debug')
 
     return len(self)
 
@@ -228,7 +230,7 @@ class Policy(core.CoreObject):
       rules = getattr(self, rule_type)
       if rules:
         for rule in rules['item']:
-          self.rules['{}-{}'.format(rule_type.replace('rule_ids', ''), rule)] = None
+          self.rules['{0}-{1}'.format(rule_type.replace('rule_ids', ''), rule)] = None
 
   def save(self):
     """
@@ -248,7 +250,7 @@ class Policy(core.CoreObject):
     else:
       result = False
       if 'log' in dir(self):
-        self.log("Could not save the policy. Returned: {}".format(response), level='error')
+        self.log("Could not save the policy. Returned: {0}".format(response), level='error')
 
     return result
 


### PR DESCRIPTION
2 major changes are made to make this library compatible with Python 2.6
1. Moved away from Python 3.x style of format
2. Moved away from Python 2.7+ SSL_Context to simply use requests library. 

Both are geared toward Python 2.6 dependencies; which is still used on a lot of legacy systems.  